### PR TITLE
Connect cart checkout button to Shopify

### DIFF
--- a/src/lib/shopify/checkout.ts
+++ b/src/lib/shopify/checkout.ts
@@ -1,0 +1,18 @@
+export function getNumericId(gid: string): string {
+  if (gid.startsWith('gid://')) {
+    const parts = gid.split('/');
+    return parts[parts.length - 1];
+  }
+  return gid;
+}
+
+import type { CartItem } from '@/types/cart';
+import { getEnv } from '@/lib/get-env';
+
+export function buildCheckoutUrl(items: CartItem[]): string {
+  const { SHOPIFY_DOMAIN } = getEnv();
+  const params = items
+    .map((item) => `${getNumericId(item.id)}:${item.quantity}`)
+    .join(',');
+  return `https://${SHOPIFY_DOMAIN}/cart/${params}`;
+}

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { motion } from "framer-motion"
 import {
     ShoppingBag,
@@ -30,6 +30,7 @@ import type { RelatedProduct } from "@/types/product"
 import {Link} from "react-router"
 import RelatedProducts from "@/components/pages/shop-item/related-products"
 import {useCart} from "@/hooks/use-cart"
+import { buildCheckoutUrl } from "@/lib/shopify/checkout"
 
 export default function CartPage() {
     const [discountInput, setDiscountInput] = useState("")
@@ -64,6 +65,8 @@ export default function CartPage() {
     }
 
     const total = subtotal + shipping + tax - discount
+
+    const checkoutUrl = useMemo(() => buildCheckoutUrl(cart), [cart])
 
     // Handle apply discount code
     const handleApplyDiscount = () => {
@@ -451,10 +454,10 @@ export default function CartPage() {
 
                                 {/* Checkout Button */}
                                 <Button asChild size="lg" className="w-full">
-                                    <Link to="/checkout">
+                                    <a href={checkoutUrl} rel="noopener noreferrer">
                                         <ShoppingBag className="h-4 w-4 mr-2" />
                                         Proceed to Checkout
-                                    </Link>
+                                    </a>
                                 </Button>
 
                                 {/* Secure Checkout */}


### PR DESCRIPTION
## Summary
- add checkout URL helper for Shopify storefront
- build checkout link from cart items
- update checkout button to open Shopify checkout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684eb8a0f69c8333b86009e982593932