### PR TITLE
Fix hero overlay layout

### DIFF
--- a/src/components/pages/landing-page/hero.tsx
+++ b/src/components/pages/landing-page/hero.tsx
@@ -7,44 +7,44 @@ import {Link} from "react-router"; // adjust this path as needed
 const HeroSection = () => {
     return (
         <section
-            className="flex flex-col md:flex-row font-dm-sans min-h-[600px] md:min-h-screen w-full overflow-hidden">
-            {/* Left: Text Section */}
-            <div className="w-full md:w-1/2 flex flex-col justify-center px-8 md:px-16 py-12 bg-zinc-100">
-                <h1 className="text-4xl sm:text-5xl lg:text-6xl font-semibold leading-tight text-black">
-                    Beauty <br /> wakes up skin <br /> at night
-                </h1>
-                <p className="text-gray-500 mt-4 md:mt-6 max-w-md">
-                    Celebrate love with our exquisite jewellery, symbolizing the timeless bond between two souls
-                </p>
+            className="relative font-dm-sans min-h-[600px] md:min-h-screen w-full overflow-hidden">
+            {/* Background Image */}
+            <img
+                src={HeroImage}
+                alt="Hero"
+                className="absolute inset-0 w-full h-full object-cover object-center"
+                style={{ objectPosition: 'center top' }}
+            />
 
-                <div className="mt-6 md:mt-8 flex items-center gap-4 md:gap-6">
-                    <Button className="font-medium hover:opacity-90">
-                        Shop Now
-                    </Button>
-                    <Button asChild variant="link" className="font-medium">
-                        <Link to="shop">
-                            All Products
-                        </Link>
-                    </Button>
-                </div>
+            {/* Overlay */}
+            <div className="relative flex items-center h-full">
+                <div
+                    className="w-full md:w-[70%] bg-zinc-100/80 flex flex-col justify-center px-8 md:px-16 py-12 backdrop-blur-sm">
+                    <h1 className="text-4xl sm:text-5xl lg:text-6xl font-semibold leading-tight text-black">
+                        Beauty <br /> wakes up skin <br /> at night
+                    </h1>
+                    <p className="text-gray-500 mt-4 md:mt-6 max-w-md">
+                        Celebrate love with our exquisite jewellery, symbolizing the timeless bond between two souls
+                    </p>
 
-                <button>
-                    <div className="mt-12 md:mt-16 flex items-center gap-2 text-sm text-gray-400">
-                        <span className="animate-[bounce_2.5s_infinite]">↓</span>
-                        <span>Scroll down</span>
+                    <div className="mt-6 md:mt-8 flex items-center gap-4 md:gap-6">
+                        <Button className="font-medium hover:opacity-90">
+                            Shop Now
+                        </Button>
+                        <Button asChild variant="link" className="font-medium">
+                            <Link to="shop">
+                                All Products
+                            </Link>
+                        </Button>
                     </div>
-                </button>
 
-            </div>
-
-            {/* Right: Image Section */}
-            <div className="w-full md:w-1/2 h-64 md:h-full overflow-hidden relative bg-[#f1c6cc]">
-                <img
-                    src={HeroImage}
-                    alt="Hero"
-                    className="w-full h-full object-cover object-center"
-                    style={{ objectPosition: 'center top' }} // adjust as needed to center on the face
-                />
+                    <button>
+                        <div className="mt-12 md:mt-16 flex items-center gap-2 text-sm text-gray-400">
+                            <span className="animate-[bounce_2.5s_infinite]">↓</span>
+                            <span>Scroll down</span>
+                        </div>
+                    </button>
+                </div>
             </div>
         </section>
     );


### PR DESCRIPTION
## Summary
- overlay hero text on the hero image instead of using two blocks
- keep the background image full width

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6854142e95088333881534f11f05d830