### PR TITLE
Remove tax on cart page

### DIFF
--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -53,7 +53,6 @@ export default function CartPage() {
     // Calculate cart summary
     const subtotal = getCartTotal()
     const shipping = subtotal > 150 ? 0 : 15
-    const tax = subtotal * 0.08 // 8% tax rate
     let discount = 0
 
     if (discountCode) {
@@ -64,7 +63,7 @@ export default function CartPage() {
         }
     }
 
-    const total = subtotal + shipping + tax - discount
+    const total = subtotal + shipping - discount
 
     const checkoutUrl = useMemo(() => buildCheckoutUrl(cart), [cart])
 
@@ -381,9 +380,9 @@ export default function CartPage() {
                                         </div>
                                     )}
 
-                                    <div className="flex justify-between">
+                                    <div className="flex justify-between hidden">
                                         <span className="text-muted-foreground">Tax (8%)</span>
-                                        <span>£{formatPrice(tax)}</span>
+                                        <span>£0.00</span>
                                     </div>
 
                                     {discount > 0 && (


### PR DESCRIPTION
## Summary
- removed tax calculation from cart
- hide the tax row in the order summary

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855430ad1548333a69155ff5c459a9a