### PR TITLE
Use variant price for product page

### DIFF
--- a/src/components/pages/product/ProductInfo.tsx
+++ b/src/components/pages/product/ProductInfo.tsx
@@ -1,7 +1,10 @@
 import { Badge } from "@/components/ui/badge"
 import { useProductContext } from "@/context/product-context"
 
-export function ProductInfo() {
+interface ProductInfoProps {
+    price?: number
+}
+export function ProductInfo({ price }: ProductInfoProps) {
     const { product } = useProductContext()
 
     const calculateDiscountedPrice = (price: number, discount?: number) => {
@@ -13,23 +16,25 @@ export function ProductInfo() {
         return price.toFixed(2)
     }
 
+    const displayPrice = price ?? product.price
+
     return (
         <div className="space-y-4">
             <div className="flex items-baseline gap-2">
                 {product.discount ? (
                     <>
                         <span className="text-2xl font-bold">
-                            £{formatPrice(calculateDiscountedPrice(product.price, product.discount))}
+                            £{formatPrice(calculateDiscountedPrice(displayPrice, product.discount))}
                         </span>
                         <span className="text-lg text-muted-foreground line-through">
-                            £{formatPrice(product.price)}
+                            £{formatPrice(displayPrice)}
                         </span>
                         <Badge variant="outline" className="ml-2 bg-primary/10 text-primary border-primary/20">
                             {product.discount}% OFF
                         </Badge>
                     </>
                 ) : (
-                    <span className="text-2xl font-bold">£{formatPrice(product.price)}</span>
+                    <span className="text-2xl font-bold">£{formatPrice(displayPrice)}</span>
                 )}
             </div>
 

--- a/src/pages/shop/item.tsx
+++ b/src/pages/shop/item.tsx
@@ -33,12 +33,14 @@ export default function ProductPage() {
         quantityAvailable: product?.stockQuantity ?? 0
     })
 
-    // Set default color when product loads
+    // Set defaults when product loads
     useEffect(() => {
         if (product && !selectedOptions.color) {
             setSelectedOptions((prev) => ({
                 ...prev,
                 color: product.colors[0]?.value ?? null,
+                price: product.price,
+                quantityAvailable: product.stockQuantity,
             }))
         }
     }, [product, selectedOptions.color])
@@ -90,7 +92,7 @@ export default function ProductPage() {
 
                             {/* Product Details */}
                             <div className="space-y-6">
-                                <ProductInfo />
+                                <ProductInfo price={selectedOptions.price} />
                                 <ProductOptions onOptionChange={setSelectedOptions} />
                                 <ProductActions selectedOptions={selectedOptions} />
                                 <ProductShipping />


### PR DESCRIPTION
## Summary
- show price from variant on single item page
- update default options to include price and stock

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855471ee3dc8333a9aa4382c5033d15