### PR TITLE
Add length data from Shopify variants

### DIFF
--- a/src/lib/helpers/mapShopifyProductToProduct.ts
+++ b/src/lib/helpers/mapShopifyProductToProduct.ts
@@ -46,6 +46,20 @@ export function mapShopifyProductToProduct(shopify: ShopifyProduct): Product {
         inStock: true
     }));
 
+    // Determine product length category based on the first variant length value
+    let productLength: string = "default";
+    const firstLengthOption = firstVariant?.selectedOptions?.find(
+        opt => opt.name.toLowerCase() === "length"
+    );
+    if (firstLengthOption) {
+        const parsed = parseFloat(firstLengthOption.value);
+        if (!Number.isNaN(parsed)) {
+            if (parsed <= 14) productLength = "short";
+            else if (parsed <= 22) productLength = "medium";
+            else productLength = "long";
+        }
+    }
+
     return {
         id: shopify.id,
         slug: shopify.handle,
@@ -76,7 +90,7 @@ export function mapShopifyProductToProduct(shopify: ShopifyProduct): Product {
         texture: (textures.length > 0 ? textures[0].value : "straight") as Product["texture"], // fallback to metafield already handled here
         type: "standard", // You can make this dynamic later
         colour: "default", // colors[0]?.value ?? "default",
-        length: "default", //lengths[0]?.value ?? "default",
+        length: productLength,
         features: parseJsonList(shopify.features?.value),
         specifications: parseKeyValueString(shopify.specifications?.value),
         careInstructions: parseJsonList(shopify.careInstructions?.value),

--- a/src/lib/shopify/products.ts
+++ b/src/lib/shopify/products.ts
@@ -30,6 +30,10 @@ const PRODUCTS_QUERY = `
                 currencyCode
               }
               quantityAvailable
+              selectedOptions {
+                name
+                value
+              }
             }
           }
         }

--- a/src/pages/shop/listing.tsx
+++ b/src/pages/shop/listing.tsx
@@ -1,5 +1,9 @@
 import { useGetProducts } from "@/hooks/shopify/products";
-import {type FilterState, ProductsListingContext, type ProductsListingContextProps} from "@/context/listing-context";
+import {
+    type FilterState,
+    ProductsListingContext,
+    type ProductsListingContextProps,
+} from "@/context/listing-context";
 import { HeroBanner } from "@/components/pages/listing/hero-banner";
 import { HighlightedProducts } from "@/components/pages/listing/highlighted-products";
 import { Filters } from "@/components/pages/listing/filters";
@@ -8,7 +12,15 @@ import { ActiveFilters } from "@/components/pages/listing/active-filters";
 import { ProductGrid } from "@/components/pages/listing/product-grid";
 import { Pagination } from "@/components/pages/listing/pagination";
 import type {Product} from "@/types/product";
-import {useCallback, useMemo, useState, useEffect} from "react";
+import { useCallback, useMemo, useState, useEffect } from "react";
+
+function classifyLength(value: string): string | null {
+    const num = parseFloat(value);
+    if (Number.isNaN(num)) return null;
+    if (num <= 14) return "short";
+    if (num <= 22) return "medium";
+    return "long";
+}
 
 
 
@@ -110,7 +122,13 @@ export function ProductsListingProvider({ children, products }: { children: Reac
         // Apply length filters
         if (activeFilters.lengths.length > 0) {
             result = result.filter((product) =>
-                activeFilters.lengths.includes(product.length)
+                product.lengths.some((l) => {
+                    const category = classifyLength(l.value);
+                    return (
+                        category !== null &&
+                        activeFilters.lengths.includes(category)
+                    );
+                })
             );
         }
 


### PR DESCRIPTION
## Summary
- include selected options in the product list query
- derive a short/medium/long category from the first variant in `mapShopifyProductToProduct`
- filter listing results by classifying available variant lengths

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6871865abab88333b8427738cd555ca4