### PR TITLE
Support video media from Shopify

### DIFF
--- a/src/lib/helpers/mapShopifyProductToProduct.ts
+++ b/src/lib/helpers/mapShopifyProductToProduct.ts
@@ -78,11 +78,28 @@ export function mapShopifyProductToProduct(shopify: ShopifyProduct): Product {
                     ? "low_stock"
                     : "in_stock",
         sku: firstVariant?.sku ?? "",
-        images: shopify.images.edges.map((edge, i) => ({
-            id: i,
-            url: edge.node.url,
-            alt: edge.node.altText ?? "",
-        })),
+        images: (shopify.media?.edges && shopify.media.edges.length > 0
+            ? shopify.media.edges.map((edge, i) => {
+                if (edge.node.mediaContentType === "VIDEO") {
+                    return {
+                        id: i,
+                        url: edge.node.previewImage?.url ?? "",
+                        alt: "",
+                        isVideo: true,
+                    };
+                }
+                return {
+                    id: i,
+                    url: edge.node.image?.url ?? "",
+                    alt: edge.node.image?.altText ?? "",
+                };
+            })
+            : shopify.images.edges.map((edge, i) => ({
+                id: i,
+                url: edge.node.url,
+                alt: edge.node.altText ?? "",
+            }))
+        ),
         colors,
         lengths,
         textures,

--- a/src/lib/shopify/products.ts
+++ b/src/lib/shopify/products.ts
@@ -20,6 +20,28 @@ const PRODUCTS_QUERY = `
             }
           }
         }
+        media(first: 5) {
+          edges {
+            node {
+              mediaContentType
+              ... on MediaImage {
+                image {
+                  url
+                  altText
+                }
+              }
+              ... on Video {
+                sources {
+                  url
+                  mimeType
+                }
+                previewImage {
+                  url
+                }
+              }
+            }
+          }
+        }
         variants(first: 5) {
           edges {
             node {
@@ -75,6 +97,28 @@ const PRODUCT_BY_HANDLE_QUERY = `
           node {
             url
             altText
+          }
+        }
+      }
+      media(first: 5) {
+        edges {
+          node {
+            mediaContentType
+            ... on MediaImage {
+              image {
+                url
+                altText
+              }
+            }
+            ... on Video {
+              sources {
+                url
+                mimeType
+              }
+              previewImage {
+                url
+              }
+            }
           }
         }
       }

--- a/src/lib/shopify/types.ts
+++ b/src/lib/shopify/types.ts
@@ -5,6 +5,18 @@ export interface ShopifyImage {
     altText: string | null;
 }
 
+export interface ShopifyVideoSource {
+    url: string;
+    mimeType?: string;
+}
+
+export interface ShopifyMedia {
+    mediaContentType: string;
+    image?: ShopifyImage;
+    previewImage?: { url: string };
+    sources?: ShopifyVideoSource[];
+}
+
 export interface ShopifyVariant {
     id: string;
     sku: string;
@@ -35,6 +47,9 @@ export interface ShopifyProduct {
     tags: string[];
     images: {
         edges: Edge<ShopifyImage>[];
+    };
+    media?: {
+        edges: Edge<ShopifyMedia>[];
     };
     variants: {
         edges: Edge<ShopifyVariant>[];


### PR DESCRIPTION
## Summary
- extend Shopify types to include media data
- query product media in Shopify requests
- map video media to product images

## Testing
- `npx tsc --noEmit` *(fails: Output file has not been built)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/picomatch)*

------
https://chatgpt.com/codex/tasks/task_e_688a4aab1bb083339b2b4e26095b7947