### PR TITLE
Fix video playback on product pages

### DIFF
--- a/src/components/pages/shop-item/product-image-gallery.tsx
+++ b/src/components/pages/shop-item/product-image-gallery.tsx
@@ -57,18 +57,29 @@ export default function ProductImageGallery({ images }: ProductImageGalleryProps
                         className="relative h-full w-full"
                     >
                         {activeImage.isVideo ? (
-                            <div className="relative h-full w-full bg-muted flex items-center justify-center">
-                                <img
-                                    src={activeImage.url || "/placeholder.svg"}
-                                    alt={activeImage.alt}
-                                    className="object-cover"
-                                />
-                                <div className="absolute inset-0 flex items-center justify-center">
-                                    <div className="rounded-full bg-primary/90 p-4">
-                                        <Play className="h-8 w-8 text-white" fill="white" />
+                            <Dialog>
+                                <DialogTrigger asChild>
+                                    <div className="relative h-full w-full cursor-pointer bg-muted flex items-center justify-center">
+                                        <img
+                                            src={activeImage.url || "/placeholder.svg"}
+                                            alt={activeImage.alt}
+                                            className="object-cover"
+                                        />
+                                        <div className="absolute inset-0 flex items-center justify-center">
+                                            <div className="rounded-full bg-primary/90 p-4">
+                                                <Play className="h-8 w-8 text-white" fill="white" />
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
-                            </div>
+                                </DialogTrigger>
+                                <DialogContent className="max-w-4xl">
+                                    <video
+                                        controls
+                                        className="w-full h-full"
+                                        src={activeImage.videoSources?.[0]?.url}
+                                    />
+                                </DialogContent>
+                            </Dialog>
                         ) : (
                             <Dialog>
                                 <DialogTrigger asChild>

--- a/src/lib/helpers/mapShopifyProductToProduct.ts
+++ b/src/lib/helpers/mapShopifyProductToProduct.ts
@@ -86,6 +86,10 @@ export function mapShopifyProductToProduct(shopify: ShopifyProduct): Product {
                         url: edge.node.previewImage?.url ?? "",
                         alt: "",
                         isVideo: true,
+                        videoSources: edge.node.sources?.map((s) => ({
+                            url: s.url,
+                            mimeType: s.mimeType,
+                        })),
                     };
                 }
                 return {

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -6,6 +6,7 @@ export interface ProductImage {
     url: string
     alt: string
     isVideo?: boolean
+    videoSources?: { url: string; mimeType?: string }[]
 }
 
 // Product color type


### PR DESCRIPTION
## Summary
- include `videoSources` for product images
- map video sources from Shopify
- show playable video when users click the preview image

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm run build` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_688abc4cb5a48333bcb781d94d2f2a05