### PR TITLE
Fix video playback on product pages

### DIFF
--- a/src/components/pages/shop-item/product-image-gallery.tsx
+++ b/src/components/pages/shop-item/product-image-gallery.tsx
@@ -57,17 +57,20 @@ export default function ProductImageGallery({ images }: ProductImageGalleryProps
                         className="relative h-full w-full"
                     >
                         {activeImage.isVideo ? (
-                            <div className="relative h-full w-full bg-muted flex items-center justify-center">
-                                <img
-                                    src={activeImage.url || "/placeholder.svg"}
-                                    alt={activeImage.alt}
-                                    className="object-cover"
-                                />
-                                <div className="absolute inset-0 flex items-center justify-center">
-                                    <div className="rounded-full bg-primary/90 p-4">
-                                        <Play className="h-8 w-8 text-white" fill="white" />
-                                    </div>
-                                </div>
+                            <div className="relative h-full w-full">
+                                <video
+                                    controls
+                                    className="h-full w-full object-cover"
+                                    poster={activeImage.url || "/placeholder.svg"}
+                                >
+                                    {activeImage.videoSources?.map((source) => (
+                                        <source
+                                            key={source.url}
+                                            src={source.url}
+                                            type={source.mimeType}
+                                        />
+                                    ))}
+                                </video>
                             </div>
                         ) : (
                             <Dialog>

--- a/src/lib/helpers/mapShopifyProductToProduct.ts
+++ b/src/lib/helpers/mapShopifyProductToProduct.ts
@@ -86,6 +86,10 @@ export function mapShopifyProductToProduct(shopify: ShopifyProduct): Product {
                         url: edge.node.previewImage?.url ?? "",
                         alt: "",
                         isVideo: true,
+                        videoSources: edge.node.sources?.map((s) => ({
+                            url: s.url,
+                            mimeType: s.mimeType,
+                        })),
                     };
                 }
                 return {

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -6,6 +6,7 @@ export interface ProductImage {
     url: string
     alt: string
     isVideo?: boolean
+    videoSources?: { url: string; mimeType?: string }[]
 }
 
 // Product color type


### PR DESCRIPTION
## Summary
- show playable videos inline in the product image gallery
- keep zoom dialog for images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: numerous TS errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688abc4cb5a48333bcb781d94d2f2a05